### PR TITLE
fix: service account token when automountServiceAccountToken is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ---
+## [1.1.1-bb.4] (2025-11-14)
+### Changed
+- modified serviceAccount to define automountServiceAccountToken to false, and modified deployment to use volumeProjection and downwardApi to mount the token.
+
 ## [1.1.1-bb.3] (2025-10-22)
 ### Changed
 - Redis updated from 22.0.7 to 23.1.1

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: authservice
 description: A Helm chart for Kubernetes
 type: application
-version: 1.1.1-bb.3
+version: 1.1.1-bb.4
 appVersion: 1.1.1
 dependencies:
   - name: redis

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
               readOnly: true
             - name: ca-bundle
               mountPath: /mnt/ca-bundle
+            {{- if .Values.serviceAccount.create }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: serviceaccount-info
+            {{- end }}
       {{- if .Values.redis.enabled }}
         - name: wait-for-redis
           image: "{{ index .Values "redis-bb" "upstream" "image" "registry" }}/{{ index .Values "redis-bb" "upstream" "image" "repository" }}:{{ index .Values "redis-bb" "upstream" "image" "tag" }}"
@@ -122,4 +126,16 @@ spec:
         - name: ca-bundle
           emptyDir:
             sizeLimit: 5Mi
-        {{- end}}
+        {{- end }}
+        {{- if .Values.serviceAccount.create }}
+        - name: serviceaccount-info
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+            - downwardAPI:
+                items:
+                - path: namespace
+                  fieldRef:
+                    fieldPath: metadata.namespace
+        {{- end }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: false
 metadata:
   name: {{ include "authservice.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Hardens this repo by setting the automountServiceAccountToken value to false in the ServiceAccount, and then uses volumeProjection to mount the ServiceAccount to the container, as well as downwardApi for the namespace.

Without the projection, and the automountServiceAccountToken is false, a cryptic error is returned that the `/var/run/secrets/kubernetes.io/serviceaccount/namespace` file was not found.